### PR TITLE
Make Dropbox::API::Object#response accessible

### DIFF
--- a/lib/dropbox-api/objects/object.rb
+++ b/lib/dropbox-api/objects/object.rb
@@ -2,11 +2,12 @@ module Dropbox
   module API
 
     class Object
-      attr_accessor :client, :deleted
+      attr_accessor :client, :deleted, :response
 
       def initialize(response, client)
         self.deleted = false
         self.client  = client
+        self.response = response
       end
 
       def self.resolve_class(hash)


### PR DESCRIPTION
Methods like `File#direct_url` return the Dropbox response wrapped inside a `Object`, exposing `response` allows to access the response data.